### PR TITLE
Added dns_name output and example for EC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,13 @@ resource "aws_instance" "example-instance-with-efs" {
 }
 
 ```
+
+Please note that you need to take care of adding some EFS/NFS capabilities to your instance first. For example, when running this on ubuntu, you can add the following lines to the start of your provisioner-script:
+```hcl-terraform
+    inline = [
+      # Install dependencies required for ubuntu
+      "sudo apt-get update",
+      "sudo apt-get install -y nfs-common",
+      # [...]
+    ]
+```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ resource "aws_instance" "example-instance-with-efs" {
       # create a directory to mount our efs volume to
       "sudo mkdir -p /mnt/efs",
       # mount the efs volume
-      "sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${module.efs_mount.file_system_dns_name}:/ efs",
+      "sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${module.efs_mount.file_system_dns_name}:/ /mnt/efs",
       # create fstab entry to ensure automount on reboots
       # https://docs.aws.amazon.com/efs/latest/ug/mount-fs-auto-mount-onreboot.html#mount-fs-auto-mount-on-creation
       "sudo su -c \"echo '${module.efs_mount.file_system_dns_name}:/ /mnt/efs nfs defaults,vers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport 0 0' >> /etc/fstab\"" #create fstab entry to ensure automount on reboots

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ resource "aws_instance" "example-instance-with-efs" {
       # create a directory to mount our efs volume to
       "sudo mkdir -p /mnt/efs",
       # mount the efs volume
-      "sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${module.efs_mount.dns_name}:/ efs",
+      "sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${module.efs_mount.file_system_dns_name}:/ efs",
       # create fstab entry to ensure automount on reboots
       # https://docs.aws.amazon.com/efs/latest/ug/mount-fs-auto-mount-onreboot.html#mount-fs-auto-mount-on-creation
-      "sudo su -c \"echo '${module.efs_mount.dns_name}:/ /mnt/efs nfs defaults,vers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport 0 0' >> /etc/fstab\"" #create fstab entry to ensure automount on reboots
+      "sudo su -c \"echo '${module.efs_mount.file_system_dns_name}:/ /mnt/efs nfs defaults,vers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport 0 0' >> /etc/fstab\"" #create fstab entry to ensure automount on reboots
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ module "efs_mount" {
   name    = "my-efs-mount"
   subnets = "subnet-abcd1234,subnet-efgh5678"
   vpc_id  = "vpc-abcd1234"
-
 }
 ```
 
@@ -29,8 +28,51 @@ The following attributes are exported:
 
 - ``name`` - The reference_name of the file system.
 - ``file_system_id`` - The ID of the file system.
+- ``file_system_dns_name`` - The DNS name of the file system.
 - ``mount_target_ids`` - A comma separated list of mount target ids.
 - ``mount_target_interface_ids`` - A comma separated list of network interface ids.
 - ``ec2_security_group_id`` - The ID of the security group to apply to EC2 instances.
 - ``mnt_security_group_id`` - The ID of the security group applied to mount targets.
 
+## How to use in EC2-Instance
+
+You can allow access to the EFS and mount it in an EC2 instance like this:
+
+```hcl-terraform
+resource "aws_key_pair" "user-ssh-key" {
+  key_name   = "your-key-name"
+  public_key = "your-public-ssh-key"
+}
+
+resource "aws_instance" "example-instance-with-efs" {
+  ami                    = "ami-abc123"
+  subnet_id              = "subnet-345abc"
+  vpc_security_group_ids = [
+    "${module.efs_mount.ec2_security_group_id}", # EFS access
+  ]
+  instance_type          = "t2.micro"
+
+  key_name = "${aws_key_pair.user-ssh-key.key_name}"
+
+  provisioner "remote-exec" {
+    connection {
+      type = "ssh"
+      user = "ubuntu"
+      private_key = "${file("~/.ssh/id_rsa")}"
+    }
+
+    inline = [
+      # mount EFS volume
+      # https://docs.aws.amazon.com/efs/latest/ug/gs-step-three-connect-to-ec2-instance.html
+      # create a directory to mount our efs volume to
+      "sudo mkdir -p /mnt/efs",
+      # mount the efs volume
+      "sudo mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport ${module.efs_mount.dns_name}:/ efs",
+      # create fstab entry to ensure automount on reboots
+      # https://docs.aws.amazon.com/efs/latest/ug/mount-fs-auto-mount-onreboot.html#mount-fs-auto-mount-on-creation
+      "sudo su -c \"echo '${module.efs_mount.dns_name}:/ /mnt/efs nfs defaults,vers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport 0 0' >> /etc/fstab\"" #create fstab entry to ensure automount on reboots
+    ]
+  }
+}
+
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following attributes are exported:
 
 You can allow access to the EFS and mount it in an EC2 instance like this:
 
-```hcl-terraform
+```hcl
 resource "aws_key_pair" "user-ssh-key" {
   key_name   = "your-key-name"
   public_key = "your-public-ssh-key"
@@ -78,7 +78,7 @@ resource "aws_instance" "example-instance-with-efs" {
 ```
 
 Please note that you need to take care of adding some EFS/NFS capabilities to your instance first. For example, when running this on ubuntu, you can add the following lines to the start of your provisioner-script:
-```hcl-terraform
+```hcl
     inline = [
       # Install dependencies required for ubuntu
       "sudo apt-get update",

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "file_system_id" {
 }
 
 output "file_system_dns_name" {
-  value = "${aws_efs_file_system.efs.id}"
+  value = "${aws_efs_file_system.efs.dns_name}"
 }
 
 output "mount_target_ids" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,10 @@ output "file_system_id" {
   value = "${aws_efs_file_system.efs.id}"
 }
 
+output "file_system_dns_name" {
+  value = "${aws_efs_file_system.efs.id}"
+}
+
 output "mount_target_ids" {
   value = "${join(",", aws_efs_mount_target.efs.*.id)}"
 }


### PR DESCRIPTION
I had a hard time figuring out how to actually use the EFS in an EC2 instance, so I added an output for the dns_name to make that a bit easier and extended the readme to include an example as to how to use it.